### PR TITLE
docs: focus README on political news

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-**BriefAI** takes a ChatGPT prompt that pulls the latest election news and market data and sends the information as a daily email via the Python email libary. I will be running the script daily on Task Scheduler on my local.
+**BriefAI** takes a ChatGPT prompt that pulls the latest election news and sends the information as a daily email via the Python email library. It currently focuses solely on political updates retrieved from NewsAPI. I will be running the script daily on Task Scheduler on my local.
 
 The goal is to generalize this and create a UI where users can customize the types of news/information being sent as well as how it is sent to their mobile device. Increased customizability could potentially be monetized and shipped as a mobile app.
 
@@ -12,7 +12,7 @@ The goal is to generalize this and create a UI where users can customize the typ
 
 ## Features
 
-- Run ChatGPT API with hardcoded and user provided prompts to generate news blurb.
+- Run ChatGPT API with hardcoded and user provided prompts to generate political news blurbs.
 - Send news blurb to user via email or other mobile channels.
 - Eventually provide a mobile UI/UX for users to customize news/info being sent as well as channels being used.
 


### PR DESCRIPTION
## Summary
- clarify that BriefAI retrieves election news only and highlight its focus on political updates
- update feature list to mention generation of political news blurbs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a679fc277c8332a1334606923f0a5d